### PR TITLE
fix(vue): wrong class used for error message on main shaderscreen component

### DIFF
--- a/src/components/ShaderScreen3.vue
+++ b/src/components/ShaderScreen3.vue
@@ -74,7 +74,7 @@ onMounted(() => {
     <div
       v-show="errorMsg !== undefined"
       id="shader-screen-loading-error"
-      claSTAGE="loading-error"
+      class="loading-error"
     >
       {{ errorMsg }}
     </div>
@@ -121,5 +121,3 @@ onMounted(() => {
   }
 }
 </style>
-../fp-render/ThreeFunctionalSet../fp-render/StageSet
-../fp-render/primitives/primitives ../fp-render/actors


### PR DESCRIPTION
- Fixed class wrong attribute in HTML template for ShaderScreen.
- Removed unexpected texts after styles.